### PR TITLE
fix silentArgs to handle disable start on logon

### DIFF
--- a/nvda/tools/chocolateyInstall.ps1
+++ b/nvda/tools/chocolateyInstall.ps1
@@ -14,7 +14,7 @@ $packageArgs = @{
   packageName    = $packageName
   fileType       = $fileType
   file           = $embedded_path
-  silentArgs     = '--install-silent' + ($params -join ' ')
+  silentArgs     = '--install-silent',($params -join ' ') -join " "
   validExitCodes = @(0)
   softwareName   = $packageName.ToUpper()
 }

--- a/nvda/tools/chocolateyInstall.ps1
+++ b/nvda/tools/chocolateyInstall.ps1
@@ -14,7 +14,7 @@ $packageArgs = @{
   packageName    = $packageName
   fileType       = $fileType
   file           = $embedded_path
-  silentArgs     = '--install-silent',($params -join ' ') -join " "
+  silentArgs     = '--install-silent',($params -join ' ') -join ' '
   validExitCodes = @(0)
   softwareName   = $packageName.ToUpper()
 }


### PR DESCRIPTION
Currently the --install-silent and --enable-start-on-logon flags are concatenated without space, resulting in both flags being ignored. This PR fixes the issue.